### PR TITLE
Support initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ It would be more useful to use this with other GitHub Actions' outputs.
 
 ## Inputs
 
-|     NAME      |                                       DESCRIPTION                                       |  TYPE  | REQUIRED | DEFAULT |
-| ------------- | --------------------------------------------------------------------------------------- | ------ | -------- | ------- |
-| `semver_only` | Whether gets only a tag in the shape of semver. `'v'` prefix is accepted for tag names. | `bool` | `false`  | `false` |
+|          NAME          |                                                  DESCRIPTION                                                  |   TYPE   | REQUIRED | DEFAULT  |
+|------------------------|---------------------------------------------------------------------------------------------------------------|----------|----------|----------|
+| `semver_only`          | Whether gets only a tag in the shape of semver. `v` prefix is accepted for tag names.                         | `bool`   | `false`  | `false`  |
+| `initial_version`      | The initial version. Works only when `inputs.with_initial_version` == `true`.                                 | `string` | `false`  | `v0.0.0` |
+| `with_initial_version` | Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available. | `bool`   | `false`  | `true`   |
 
 If `inputs.semver_only` is `true`, the latest tag among tags with semver will be set for `outputs.tag`.
 
@@ -35,9 +37,9 @@ In such a case, `outputs.tag` varies like this:
 
 ## Outputs
 
-| NAME  |                      DESCRIPTION                      |   TYPE   |
-| ----- | ----------------------------------------------------- | -------- |
-| `tag` | The latest tag. If no tag exists, this value is `''`. | `string` |
+| NAME  |                                            DESCRIPTION                                             |   TYPE   |
+|-------|----------------------------------------------------------------------------------------------------|----------|
+| `tag` | The latest tag. If no tag exists and `inputs.with_initial_version` == `false`, this value is `''`. | `string` |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -3,12 +3,20 @@ description: Get a latest Git tag.
 author: Actions Ecosystem
 inputs:
   semver_only:
-    description: Whether gets only a tag in the shape of semver. 'v' prefix is accepted for tag names.
+    description: Whether gets only a tag in the shape of semver. `v` prefix is accepted for tag names.
     required: false
     default: "false"
+  initial_version:
+    description: The initial version. Works only when `inputs.with_initial_version` == `true`.
+    required: false
+    default: "v0.0.0"
+  with_initial_version:
+    description: Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available.
+    required: false
+    default: "true"
 outputs:
   tag:
-    description: The latest tag. If no tag exists, this value is ''.
+    description: The latest tag. If no tag exists and `inputs.with_initial_version` == `false`, this value is `''`.
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,4 +20,8 @@ else
     done
 fi
 
+if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; then
+    latest_tag="${INPUT_INITIAL_VERSION}"
+fi
+
 echo "::set-output name=tag::${latest_tag}"


### PR DESCRIPTION
## Release Note

```release_note
## What's New

- Allowed the action return the initial version as `outputs.tag`
  - Added `inputs.initial_version` and `inputs.with_initial_version`
```