### PR TITLE
Fix wrong fetching semver latest tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,20 +8,21 @@ git fetch --prune --unshallow
 latest_tag=''
 
 if [ "${INPUT_SEMVER_ONLY}" = 'false' ]; then
-    # Get a actual latest tag.
-    latest_tag=$(git describe --abbrev=0 --tags)
+  # Get a actual latest tag.
+  latest_tag=$(git describe --abbrev=0 --tags)
 else
-    # Get a latest tag in the shape of semver.
-    for tag in $(git tag | sort -r); do
-        if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
-            latest_tag="${tag}"
-            break
-        fi
-    done
+  # Get a latest tag in the shape of semver.
+  for ref in $(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags); do
+    tag="${ref#refs/tags/}"
+    if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
+      latest_tag="${tag}"
+      break
+    fi
+  done
 fi
 
 if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; then
-    latest_tag="${INPUT_INITIAL_VERSION}"
+  latest_tag="${INPUT_INITIAL_VERSION}"
 fi
 
 echo "::set-output name=tag::${latest_tag}"


### PR DESCRIPTION
## What this PR does / Why we need it

This PR fixed `outputs.tag` was wrong in some cases due to the wrong sorting. Mainly, replaced `git tag | sort -r` with `git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags`.

- Case 1:	

  In the following case, `outputs.tag` was `v0.2.0`, not `v0.10.0` we want.

  ```console
  $ git tag
  v0.1.0
  v0.10.0 # actual latest
  v0.2.0
  ```

- Case 2:

  In the following case, `outputs.tag` was `v0.1.0-rc1`, not `v0.1.0` we want.

  ```console
  $ git tag
  v0.1.0 # actual latest
  v0.1.0-rc1
  ```

### Release Note

```release_note
## What's New

- Fix wrong fetching semver latest tag
```
