### PR TITLE
Suppress 'git fetch --unshallow' error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,8 @@
 set -e
 
 git fetch --tags
-git fetch --prune --unshallow
+# This suppress an error occurred when the repository is a complete one.
+git fetch --prune --unshallow || true
 
 latest_tag=''
 
@@ -13,7 +14,7 @@ if [ "${INPUT_SEMVER_ONLY}" = 'false' ]; then
 else
   # Get a latest tag in the shape of semver.
   for ref in $(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags); do
-    tag="${ref#refs/tags/}"
+    readonly tag="${ref#refs/tags/}"
     if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
       latest_tag="${tag}"
       break


### PR DESCRIPTION
## What this PR does / Why we need it

Suppress `git fetch --unshallow`'s error with `|| true`.

When `fetch-depth == 0` in [`actions/checkout`](https://github.com/actions/checkout) as follows:

```yaml
      - uses: actions/checkout@v2
        with:
          fetch-depth: 0
```

This action omits the following error and exits with the status code `128` since the repository is a complete one.

```
fatal: --unshallow on a complete repository does not make sense
```