### PR TITLE
Support lexicographical sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ It would be more useful to use this with other GitHub Actions' outputs.
 
 ## Inputs
 
-|          NAME          |                                                  DESCRIPTION                                                  |   TYPE   | REQUIRED | DEFAULT  |
-|------------------------|---------------------------------------------------------------------------------------------------------------|----------|----------|----------|
-| `semver_only`          | Whether gets only a tag in the shape of semver. `v` prefix is accepted for tag names.                         | `bool`   | `false`  | `false`  |
-| `initial_version`      | The initial version. Works only when `inputs.with_initial_version` == `true`.                                 | `string` | `false`  | `v0.0.0` |
-| `with_initial_version` | Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available. | `bool`   | `false`  | `true`   |
+NAME | DESCRIPTION | TYPE | REQUIRED | DEFAULT
+---|---|---|---|---
+`semver_only` | Whether to return only semvar format tags. `v` prefix is accepted for tag names. | `bool` | `false` | `false`
+`initial_version` | The initial version. Works only when `inputs.with_initial_version` is set to `true`. | `string` | `false` | `v0.0.0`
+`with_initial_version` | Whether to return `inputs.initial_version` as `outputs.tag` if no tag exists | `bool` | `false` | `true`
+`sort_by_date` | Whether to sort the tags in chronological order (default) or in lexicographical order | `bool` | `false` | `true`
 
 If `inputs.semver_only` is `true`, the latest tag among tags with semver will be set for `outputs.tag`.
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available.
     required: false
     default: "true"
+  sort_by_date:
+    description: If set to `false`, the tags are sorted in lexicographical order by `refname` (which can return the largest semver tag). Defaults to `true` and returns the tag which was pushed most recently (even though it might not be the largest by semver comparison).
+    required: false
+    default: "true"
 outputs:
   tag:
     description: The latest tag. If no tag exists and `inputs.with_initial_version` == `false`, this value is `''`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,20 +7,30 @@ git fetch --tags
 git fetch --prune --unshallow || true
 
 latest_tag=''
+sort_flag='--sort=-refname'
 
-if [ "${INPUT_SEMVER_ONLY}" = 'false' ]; then
-  # Get a actual latest tag.
-  latest_tag=$(git describe --abbrev=0 --tags)
-else
-  # Get a latest tag in the shape of semver.
-  for ref in $(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags); do
-    tag="${ref#refs/tags/}"
-    if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
-      latest_tag="${tag}"
-      break
-    fi
-  done
+if [ "${INPUT_SORT_BY_DATE}" = 'true' ]; then
+  # Set the 'sort' flag
+  sort_flag='--sort=-creatordate'
 fi
+
+# Get a latest tag
+for ref in $(git for-each-ref ${sort_flag} --format '%(refname)' refs/tags); do
+  tag="${ref#refs/tags/}"
+
+  # Return if it is in semver format
+  if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
+    latest_tag="${tag}"
+    break
+  fi
+
+  # Return if the user didn't ask for semver format
+  if [ "${INPUT_SEMVER_ONLY}" = 'false' ]; then
+    # Get a actual latest tag.
+    latest_tag="${tag}"
+    break
+  fi
+done
 
 if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; then
   latest_tag="${INPUT_INITIAL_VERSION}"


### PR DESCRIPTION
Allow to return the largest tag after lexicographical sorting. This can
be usefule in returning largest semver tag. Main use case can be in the
projects where multiple versions are supported. For example, `v2.38.6`
is the latest stable version but a recent security patch was pushed in
version `v1.15.8`. Thus, it is now possible to sort in lexicographical
order and get the highest semver version (`v2.38.6`).