### PR TITLE
Supressing error if no tags on the repository but we're trying to get non-semver tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,8 @@ latest_tag=''
 
 if [ "${INPUT_SEMVER_ONLY}" = 'false' ]; then
   # Get a actual latest tag.
-  latest_tag=$(git describe --abbrev=0 --tags)
+  # If no tags found, supress an error. In such case stderr will be not stored in latest_tag variable so no additional logic is needed.
+  latest_tag=$(git describe --abbrev=0 --tags || true)
 else
   # Get a latest tag in the shape of semver.
   for ref in $(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags); do


### PR DESCRIPTION
## What this PR does / Why we need it
  Prevent to fail action if no tag available  
## Which issue(s) this PR fixes
  Resolves #16 
Fixes #
  Without it `fatal: No names found, cannot describe anything.` will happen when no tags on the repo.