### PR TITLE
Fix `fatal: unsafe repository ('/github/workspace' is owned by someon…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-git config --global --add safe.directory /gitHub/workspace
+git config --global --add safe.directory /github/workspace
 
 git fetch --tags
 # This suppress an error occurred when the repository is a complete one.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+git config --global --add safe.directory /gitHub/workspace
+
 git fetch --tags
 # This suppress an error occurred when the repository is a complete one.
 git fetch --prune --unshallow || true


### PR DESCRIPTION
…e else)`

## What this PR does / Why we need it

Looks like there were some changes to git, and this action currently errors out.

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
```

The fix is to add a safe directory (tested in a separate repo, but please test here as well).

Related Stack Overflow: https://stackoverflow.com/questions/71849415/cannot-add-parent-directory-to-safe-directory-on-git

## Which issue(s) this PR fixes

Fixes #
