### PR TITLE
Resolve failing file permissions

### DIFF
--- a/.github/workflows/action-release.yaml
+++ b/.github/workflows/action-release.yaml
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.0
+        uses: actions/publish-action@v0.2.1
         with:
           source-tag: ${{ env.TAG_NAME }}

--- a/.github/workflows/action-release.yaml
+++ b/.github/workflows/action-release.yaml
@@ -1,0 +1,26 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update the ${{ env.TAG_NAME }} tag
+        uses: actions/publish-action@v0.2.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:latest
-
-RUN apk add --no-cache git grep
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Entrypoint
       id: get-tag
-      run: ./entrypoint.sh
+      run: ${{ github.action_path }}/entrypoint.sh
       shell: bash
 branding:
   icon: bookmark

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Entrypoint
       id: get-tag
-      run: ${{ github.action_path }}/entrypoint.sh
+      run: ${{ github.action_path }}/entrypoint.sh "${{ inputs.semver_only }}" "${{ inputs.initial_version }}" "${{ inputs.with_initial_version }}"
       shell: bash
 branding:
   icon: bookmark

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: Actions Ecosystem Action Get Latest Tag
 description: Get a latest Git tag.
 author: Actions Ecosystem
+
 inputs:
   semver_only:
     description: Whether gets only a tag in the shape of semver. `v` prefix is accepted for tag names.
@@ -14,10 +15,12 @@ inputs:
     description: Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available.
     required: false
     default: 'true'
+
 outputs:
   tag:
     description: The latest tag. If no tag exists and `inputs.with_initial_version` == `false`, this value is `''`.
     value: ${{ steps.get-tag.outputs.tag }}
+
 runs:
   using: composite
   steps:
@@ -25,6 +28,7 @@ runs:
       id: get-tag
       run: ${{ github.action_path }}/entrypoint.sh "${{ inputs.semver_only }}" "${{ inputs.initial_version }}" "${{ inputs.with_initial_version }}"
       shell: bash
+
 branding:
   icon: bookmark
   color: green

--- a/action.yml
+++ b/action.yml
@@ -5,21 +5,26 @@ inputs:
   semver_only:
     description: Whether gets only a tag in the shape of semver. `v` prefix is accepted for tag names.
     required: false
-    default: "false"
+    default: 'false'
   initial_version:
     description: The initial version. Works only when `inputs.with_initial_version` == `true`.
     required: false
-    default: "v0.0.0"
+    default: 'v0.0.0'
   with_initial_version:
     description: Whether returns `inputs.initial_version` as `outputs.tag` if no tag exists. `true` and `false` are available.
     required: false
-    default: "true"
+    default: 'true'
 outputs:
   tag:
     description: The latest tag. If no tag exists and `inputs.with_initial_version` == `false`, this value is `''`.
+    value: ${{ steps.get-tag.outputs.tag }}
 runs:
-  using: docker
-  image: Dockerfile
+  using: composite
+  steps:
+    - name: Entrypoint
+      id: get-tag
+      run: ./entrypoint.sh
+      shell: bash
 branding:
   icon: bookmark
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,4 @@ if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; the
   latest_tag="${INPUT_INITIAL_VERSION}"
 fi
 
-echo "::set-output name=tag::${latest_tag}"
+echo "tag=${latest_tag}" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+INPUT_SEMVER_ONLY="$1"
+INPUT_INITIAL_VERSION="$2"
+INPUT_WITH_INITIAL_VERSION="$3"
+
 set -e
 
 git fetch --tags

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-git config --global --add safe.directory /github/workspace
-
 git fetch --tags
 # This suppress an error occurred when the repository is a complete one.
 git fetch --prune --unshallow || true


### PR DESCRIPTION
## What this PR does / Why we need it
Due to a recent security update, Docker image GHA runs no longer are provided permissions to checked out repos. 

This PR converts this GHA from a Docker image run to a composite run. This allows the bash script to be run in-place in the GHA environment, allowing it the same permissions as the environment.

It also cuts down on GHA time usage due to not having to build the Docker image on runs.

Here is an example of a successful run with these changes: https://github.com/dmsi-io/gha-prep-release/actions/runs/2270648602

## Which issue(s) this PR fixes

Fixes #
