### PR TITLE
quiet warnings, use GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ git config --global --add safe.directory /github/workspace
 
 git fetch --tags
 # This suppress an error occurred when the repository is a complete one.
-git fetch --prune --unshallow || true
+git fetch --prune --unshallow 2>/dev/null || true
 
 latest_tag=''
 
@@ -18,7 +18,7 @@ else
   # Get a latest tag in the shape of semver.
   for ref in $(git for-each-ref --sort=-creatordate --format '%(refname)' refs/tags); do
     tag="${ref#refs/tags/}"
-    if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'; then
+    if echo "${tag}" | grep -Eq '^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$' 2>/dev/null; then
       latest_tag="${tag}"
       break
     fi
@@ -29,4 +29,4 @@ if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; the
   latest_tag="${INPUT_INITIAL_VERSION}"
 fi
 
-echo "::set-output name=tag::${latest_tag}"
+echo "tag=${latest_tag}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
## What this PR does / Why we need it
This PR does two things:
- Quiets warnings that come from `grep` and `git fetch --prune --unshallow`
- Changes old version of output to $GITHUB_OUTPUT

## Which issue(s) this PR fixes

Fixes #
