### PR TITLE
Update to use GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,4 +29,4 @@ if [ "${latest_tag}" = '' ] && [ "${INPUT_WITH_INITIAL_VERSION}" = 'true' ]; the
   latest_tag="${INPUT_INITIAL_VERSION}"
 fi
 
-echo "::set-output name=tag::${latest_tag}"
+echo "tag=${latest_tag}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## What this PR does / Why we need it

Update to latest syntax

## Which issue(s) this PR fixes

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/